### PR TITLE
Bug fix

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="RXTX/i686-pc-linux-gnu/.libs"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.externalToolBuilders/Create RXTX Jar.launch
+++ b/.externalToolBuilders/Create RXTX Jar.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
+<booleanAttribute key="org.eclipse.ant.ui.ATTR_TARGETS_UPDATED" value="true"/>
+<booleanAttribute key="org.eclipse.ant.ui.DEFAULT_VM_INSTALL" value="false"/>
+<booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.ant.ui.AntClasspathProvider"/>
+<booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value=""/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/RXTX/build.xml}"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,"/>
+<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
+</launchConfiguration>

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ stamp-h1
 gnu
 x86_64-unknown-linux-gnu
 RXTXcomm.jar
+/bin/
+/i686-pc-linux-gnu/

--- a/.project
+++ b/.project
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>RXTX</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+				<dictionary>
+					<key>LaunchConfigHandle</key>
+					<value>&lt;project&gt;/.externalToolBuilders/Create RXTX Jar.launch</value>
+				</dictionary>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<!-- Configuration of the Ant build system to generate a Jar file --> 
+<project name="RXTX" default="CreateJar">
+  <target name="CreateJar" description="Create Jar file">
+        <jar jarfile="RXTXcomm.jar" basedir="./bin" includes="**/*.class" />
+  </target>
+</project>

--- a/src/SerialImp.c
+++ b/src/SerialImp.c
@@ -718,7 +718,10 @@ JNIEXPORT jint JNICALL RXTXPort(open)(
        }
 #endif /* OPEN_EXCL */
 
-	if( configure_port( fd ) ) goto fail;
+	if( configure_port( fd ) ) {
+		UNLOCK( filename, pid ); // If the device is not present (ie /dev/ttyXXX is not there), the lock file MUST be cleaned tobe able to reconnect witout manually removing /var/lock/LCK...XXXX 
+		goto fail;
+	}
 	(*env)->ReleaseStringUTFChars( env, jstr, filename );
 	sprintf( message, "open: fd returned is %i\n", fd );
 	report( message );


### PR DESCRIPTION
If the device is not present (ie /dev/ttyXXX is not there), the lock file MUST be cleaned manually by removing /var/lock/LCK...XXXX to be able to reuse the port.
