### PR TITLE
add missinig command on linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Have the necessary tools in place: on debian/ubuntu `apt-get install build-essen
 
 ```bash
 mkdir build
+cd build
 ../configure
 make
 ```


### PR DESCRIPTION
added `cd build` to the installation instructions for linux.